### PR TITLE
Prevent null from being passed to preg_replace

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -381,6 +381,10 @@ class Config implements ConfigInterface
             $storeId = $this->_storeId;
         }
 
+        if (!$key) {
+            return null;
+        }
+
         $underscored = strtolower(preg_replace('/(.)([A-Z])/', "$1_$2", $key));
 
         $path = "payment/" . self::METHOD_CODE . "/" . $underscored;

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "zip/magento2",
     "description": "Zip Payment Module for Magento 2",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "type": "magento2-module",
     "license": [
         "OSL-3.0"


### PR DESCRIPTION
preg_replace no longer allows an empty `$subject`.

Also bump up composer version